### PR TITLE
Insert delay between frame captures

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ document.getElementById('gifForm').addEventListener('submit', async (event) => {
         for (let i = 0; i < totalFrames; i++) {
             const screenshot = await page.screenshot();
             screenshots.push(screenshot);
+            await page.waitForTimeout(1000 / frameRate);
         }
 
         await browser.close();


### PR DESCRIPTION
## Summary
- throttle puppeteer screenshot loop by waiting according to the chosen framerate

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68401d22ca948321acbec8ff984784be