### PR TITLE
Add serverless GIF generation endpoint

### DIFF
--- a/src/api/generate-gif.js
+++ b/src/api/generate-gif.js
@@ -1,0 +1,46 @@
+const puppeteer = require('puppeteer');
+const gifshot = require('gifshot');
+
+module.exports = async (req, res) => {
+  const { url, width, frameRate, length } = req.body || {};
+
+  if (!url || !width || !frameRate || !length) {
+    res.status(400).json({ error: 'Missing parameters' });
+    return;
+  }
+
+  try {
+    const browser = await puppeteer.launch();
+    const page = await browser.newPage();
+    await page.goto(url, { waitUntil: 'networkidle2' });
+
+    const height = await page.evaluate(() => document.body.scrollHeight);
+    await page.setViewport({ width: parseInt(width, 10), height });
+
+    const screenshots = [];
+    const totalFrames = frameRate * length;
+    for (let i = 0; i < totalFrames; i++) {
+      const screenshot = await page.screenshot({ encoding: 'base64' });
+      screenshots.push('data:image/png;base64,' + screenshot);
+    }
+
+    await browser.close();
+
+    gifshot.createGIF({
+      images: screenshots,
+      interval: 1 / frameRate,
+      gifWidth: parseInt(width, 10),
+      gifHeight: height
+    }, obj => {
+      if (obj.error) {
+        console.error('GIF error:', obj.errorMsg);
+        res.status(500).json({ error: 'GIF generation failed' });
+      } else {
+        res.status(200).json({ gif: obj.image });
+      }
+    });
+  } catch (err) {
+    console.error('Error generating GIF:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,3 @@
-const puppeteer = require('puppeteer');
-const gifshot = require('gifshot');
-
 document.getElementById('gifForm').addEventListener('submit', async (event) => {
     event.preventDefault();
 
@@ -13,37 +10,23 @@ document.getElementById('gifForm').addEventListener('submit', async (event) => {
     document.getElementById('result').style.display = 'none';
 
     try {
-        const browser = await puppeteer.launch();
-        const page = await browser.newPage();
-        await page.goto(url, { waitUntil: 'networkidle2' });
+        const response = await fetch('/api/generate-gif', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ url, width, frameRate, length })
+        });
 
-        const height = await page.evaluate(() => document.body.scrollHeight);
-        await page.setViewport({ width, height });
-
-        const screenshots = [];
-        const totalFrames = frameRate * length;
-        for (let i = 0; i < totalFrames; i++) {
-            const screenshot = await page.screenshot();
-            screenshots.push(screenshot);
+        if (!response.ok) {
+            throw new Error('Failed to generate GIF');
         }
 
-        await browser.close();
+        const data = await response.json();
+        const downloadLink = document.getElementById('downloadLink');
+        downloadLink.href = data.gif;
+        downloadLink.download = 'website.gif';
 
-        gifshot.createGIF({
-            images: screenshots,
-            interval: 1 / frameRate,
-            gifWidth: width,
-            gifHeight: height
-        }, (obj) => {
-            if (!obj.error) {
-                const image = obj.image;
-                const downloadLink = document.getElementById('downloadLink');
-                downloadLink.href = image;
-                downloadLink.download = 'website.gif';
-                document.getElementById('loading').style.display = 'none';
-                document.getElementById('result').style.display = 'block';
-            }
-        });
+        document.getElementById('loading').style.display = 'none';
+        document.getElementById('result').style.display = 'block';
     } catch (error) {
         console.error('Error generating GIF:', error);
         document.getElementById('loading').style.display = 'none';

--- a/vercel.json
+++ b/vercel.json
@@ -6,14 +6,14 @@
       "use": "@vercel/static"
     },
     {
-      "src": "src/index.js",
+      "src": "src/api/generate-gif.js",
       "use": "@vercel/node"
     }
   ],
   "routes": [
     {
       "src": "/api/generate-gif",
-      "dest": "/src/index.js"
+      "dest": "/src/api/generate-gif.js"
     },
     {
       "src": "/(.*)",


### PR DESCRIPTION
## Summary
- create `src/api/generate-gif.js` for Puppeteer+gifshot logic
- switch `src/index.js` to browser-only script that POSTs to the API
- map `/api/generate-gif` to the new function in `vercel.json`

## Testing
- `node -c src/api/generate-gif.js`
- `node -c src/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68401d20965c8321b8f4d8d5fd0d2f49