### PR TITLE
Fix npm start entry and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ This project allows users to input any web URL and convert it into a downloadabl
    ```
    npm run dev
    ```
-5. Optionally run the API script directly:
-   ```
-   npm start
-   ```
+5. Alternatively start the Express server:
+    ```
+    npm start
+    ```
 6. Open the application in your browser:
    ```
    http://localhost:3000

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This project allows users to input any web URL and convert it into a downloadable GIF. Users can set the dimensions for the width of the GIF, and the height will automatically adjust to incorporate the full height of the supplied web page. Users can also set the frame rate and length in time of the resulting GIF. The project uses Bootstrap for UI elements and includes a loading animation.",
   "main": "src/api/generate-gif.js",
   "scripts": {
-    "start": "node src/index.js",
+    "start": "node server.js",
     "dev": "vercel dev",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -13,6 +13,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "express": "^4.18.2",
     "puppeteer": "^21.3.8",
     "gifshot": "^0.3.2"
   }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const path = require('path');
+const generateGif = require('./src/api/generate-gif');
+
+const app = express();
+app.use(express.json());
+
+// Serve static files
+app.use('/public', express.static(path.join(__dirname, 'public')));
+app.use('/src', express.static(path.join(__dirname, 'src')));
+
+// API route
+app.post('/api/generate-gif', generateGif);
+
+// Fallback to index.html for other routes
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- use an Express server as the main entrypoint
- document running the Express server in README
- depend on Express

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `PUPPETEER_SKIP_DOWNLOAD=1 npm start`

------
https://chatgpt.com/codex/tasks/task_e_68402b8684cc8321bca6c19d4ec4f6e3