### PR TITLE
Replace gifshot with gifencoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This project allows users to input any web URL and convert it into a downloadabl
 ## Dependencies
 
 - Puppeteer
-- gifshot
+- gifencoder
 - Bootstrap
 
 ## Technologies Used

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "type": "commonjs",
   "dependencies": {
     "puppeteer": "^21.3.8",
-    "gifshot": "^0.3.2"
+    "gifencoder": "^2.0.1",
+    "canvas": "^3.1.0"
   }
 }

--- a/src/api/generate-gif.js
+++ b/src/api/generate-gif.js
@@ -1,5 +1,6 @@
 const puppeteer = require('puppeteer');
-const gifshot = require('gifshot');
+const GIFEncoder = require('gifencoder');
+const { createCanvas, loadImage } = require('canvas');
 
 module.exports = async (req, res) => {
   // Support both query parameters and body parameters for flexibility
@@ -26,27 +27,41 @@ module.exports = async (req, res) => {
     const totalFrames = frameRate * length;
     
     for (let i = 0; i < totalFrames; i++) {
-      const screenshot = await page.screenshot({ encoding: 'base64' });
-      screenshots.push('data:image/png;base64,' + screenshot);
+      const screenshot = await page.screenshot();
+      screenshots.push(screenshot);
       // Add timing delay to ensure proper frame rate
       await page.waitForTimeout(1000 / frameRate);
     }
     
     await browser.close();
     
-    gifshot.createGIF({
-      images: screenshots,
-      interval: 1 / frameRate,
-      gifWidth: width,
-      gifHeight: height
-    }, (obj) => {
-      if (obj.error) {
-        console.error('GIF generation error:', obj.errorMsg);
-        res.status(500).json({ error: obj.errorMsg || 'Failed to generate GIF' });
-      } else {
-        res.status(200).json({ gif: obj.image });
-      }
+    const encoder = new GIFEncoder(width, height);
+    const canvas = createCanvas(width, height);
+    const ctx = canvas.getContext('2d');
+    const chunks = [];
+    const stream = encoder.createReadStream();
+    stream.on('data', chunk => chunks.push(chunk));
+
+    encoder.start();
+    encoder.setRepeat(0);
+    encoder.setDelay(1000 / frameRate);
+    encoder.setQuality(10);
+
+    for (const shot of screenshots) {
+      const img = await loadImage(shot);
+      ctx.drawImage(img, 0, 0, width, height);
+      encoder.addFrame(ctx);
+    }
+
+    encoder.finish();
+
+    await new Promise((resolve, reject) => {
+      stream.on('end', resolve);
+      stream.on('error', reject);
     });
+
+    const gifBuffer = Buffer.concat(chunks);
+    res.status(200).json({ gif: 'data:image/gif;base64,' + gifBuffer.toString('base64') });
   } catch (err) {
     console.error('Error generating GIF:', err);
     res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- switch GIF library from gifshot to gifencoder
- use gifencoder and canvas in the generate-gif API
- update dependencies and README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68402b8835b08321809b467318b79fee