### PR TITLE
Add Jest tests for generateGif validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,16 +6,19 @@
   "scripts": {
     "start": "node server.js",
     "dev": "vercel dev",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "canvas": "^3.1.0",
     "express": "^4.18.2",
-    "puppeteer": "^21.3.8",
     "gifencoder": "^2.0.1",
-    "canvas": "^3.1.0"
+    "puppeteer": "^21.3.8"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/tests/generate-gif.test.js
+++ b/tests/generate-gif.test.js
@@ -1,0 +1,67 @@
+// Mock puppeteer, gifshot and canvas so the handler can load without heavy deps
+jest.mock('puppeteer', () => ({
+  launch: jest.fn().mockResolvedValue({
+    newPage: jest.fn().mockResolvedValue({
+      goto: jest.fn(),
+      evaluate: jest.fn().mockResolvedValue(100),
+      setViewport: jest.fn(),
+      screenshot: jest.fn().mockResolvedValue(Buffer.from('')),
+      waitForTimeout: jest.fn(),
+    }),
+    close: jest.fn(),
+  }),
+}));
+
+jest.mock('gifshot', () => ({}), { virtual: true });
+jest.mock('canvas', () => ({ createCanvas: jest.fn(), loadImage: jest.fn() }));
+
+const generateGif = require('../src/api/generate-gif');
+
+const makeRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('generateGif parameter validation', () => {
+  test('missing url results in status 400', async () => {
+    const req = { query: { width: '100', frameRate: '1', length: '1' } };
+    const res = makeRes();
+
+    await generateGif(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Missing required parameter: url' });
+  });
+
+  test('invalid width results in status 400', async () => {
+    const req = { query: { url: 'http://example.com', width: '0', frameRate: '1', length: '1' } };
+    const res = makeRes();
+
+    await generateGif(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Width must be a positive integer up to 2000px' });
+  });
+
+  test('invalid frameRate results in status 400', async () => {
+    const req = { query: { url: 'http://example.com', width: '100', frameRate: '0', length: '1' } };
+    const res = makeRes();
+
+    await generateGif(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Frame rate must be a positive integer up to 60 fps' });
+  });
+
+  test('invalid length results in status 400', async () => {
+    const req = { query: { url: 'http://example.com', width: '100', frameRate: '1', length: '0' } };
+    const res = makeRes();
+
+    await generateGif(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Length must be a positive integer up to 60 seconds' });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest as a dev dependency and hook up `npm test`
- mock puppeteer and gifshot in new unit tests
- verify invalid parameters return the expected 400 errors

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68402e624ba8832195af15e05d3c5562